### PR TITLE
Add EAAProvider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Service type mapping
 - QEAAProvider  
 - PubEAAProvider  
 - WalletProvider  
+- EAAProvider  
 
 ## Disclaimer
 
@@ -75,7 +76,7 @@ docker-compose down
 
 - _Method_: POST
 - _URL_: http://localhost:8080/trust
-- _Actor_: [Trust](src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/TrustApi.kt)
+- _Actor_: [Trust](src/main/kotlin/eu/europa/ec/eudi/trustvalidator/adapter/input/web/TrustApi.kt)
 
 An endpoint to validates an incoming x5c chain against configured trust sources (List of Trusted Lists and/or keystores). Payload of this request is a json object with the following acceptable attributes:
 - `x5c`: X509 certificates in Base64 (DER format).
@@ -141,7 +142,7 @@ The trust sources are configured using the environment variable `TRUSTSOURCES` a
 Variable: `TRUSTSOURCES_0_PROVIDERTYPE`  
 Description: The provider type of the trust source.  
 Default value: `PIDProvider`  
-Example: `PIDProvider`, `QEAAProvider`, `PubEAAProvider`, `WalletProvider`  
+Example: `PIDProvider`, `QEAAProvider`, `PubEAAProvider`, `WalletProvider`, `EAAProvider`  
 
 Variable: `TRUSTSOURCES_0_LOTL_LOCATION`  
 Description: If present, the URL of the List of Trusted Lists from which to load the X509 Certificates for this trust source  

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/domain/ProviderType.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/domain/ProviderType.kt
@@ -15,11 +15,15 @@
  */
 package eu.europa.ec.eudi.trustvalidator.domain
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 internal enum class ProviderType {
     PIDProvider,
     QEAAProvider,
     PubEAAProvider,
     WalletProvider,
+    EAAProvider,
     ;
 
     fun toDomain(): ServiceType =
@@ -28,5 +32,6 @@ internal enum class ProviderType {
             QEAAProvider -> ServiceType.QEAAProvider
             PubEAAProvider -> ServiceType.PubEAAProvider
             WalletProvider -> ServiceType.WalletProvider
+            EAAProvider -> ServiceType.EAAProvider
         }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/domain/ValidatorConfig.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/domain/ValidatorConfig.kt
@@ -37,6 +37,7 @@ enum class ServiceType(val value: String) {
     QEAAProvider("http://uri.etsi.org/TrstSvc/Svctype/EAA/Q"),
     PubEAAProvider("http://uri.etsi.org/TrstSvc/Svctype/EAA/Pub-EAA"),
     WalletProvider("http://uri.etsi.org/TrstSvc/Svctype/Provider/Wallet"), // TODO TBD
+    EAAProvider("http://uri.etsi.org/TrstSvc/Svctype/EAA"),
 }
 
 data class TrustedListConfig(

--- a/src/main/resources/public/openapi.json
+++ b/src/main/resources/public/openapi.json
@@ -102,7 +102,8 @@
           "PIDProvider",
           "QEAAProvider",
           "PubEAAProvider",
-          "WalletProvider"
+          "WalletProvider",
+          "EAAProvider"
         ]
       },
       "TrustQueryRequest": {


### PR DESCRIPTION
Added `EAAProvider` support (which was missing) since https://github.com/eu-digital-identity-wallet/eudi-srv-verifier-endpoint/pull/491/ aims to include it.