### PR TITLE
Require KeyStoreConfigurationProperties.location be an existing readable file

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
@@ -168,7 +168,13 @@ data class KeyStoreConfigurationProperties(
     val location: Resource,
     val keyStoreType: String = "JKS",
     val password: Password? = null,
-)
+) {
+    init {
+        require(location.exists() && location.isFile && location.isReadable) {
+            "location must point to an existing readable file"
+        }
+    }
+}
 
 @JvmInline
 value class Password(val value: String) {


### PR DESCRIPTION
`KeyStoreConfigurationProperties.location` is a `Resource`.
For `KeyStoreConfigurationProperties` to be valid, `location` must be an existing readable file.

This PR introduces an `init` block in `KeyStoreConfigurationProperties` that enforces the above requirements.