### PR TITLE
Workaround `bootBuildImage` issue with ubuntu-latest Github runner

### DIFF
--- a/.github/workflows/publish-to-container-registry.yml
+++ b/.github/workflows/publish-to-container-registry.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Debug
         run: echo ${{ steps.meta.outputs }}
       - name: Build and publish with Gradle Wrapper
-        run: ./gradlew build bootBuildImage --imageName=${{ fromJSON(steps.meta.outputs.json).tags[0] }} --publishImage --full-stacktrace
+        run: ./gradlew build bootBuildImage --imageName=${{ fromJSON(steps.meta.outputs.json).tags[0] }} --imagePlatform linux/amd64 --publishImage --full-stacktrace
         if: github.event_name != 'pull_request'
         env:
           BP_OCI_CREATED: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}


### PR DESCRIPTION
An issue with paketo-buildpack prevents us from building container images using the `ubuntu-latest` Github runner.

This PR add the `--imagePlatform` parameter during `bootBuildImage` to workaround this issue.


References:
1. https://github.com/spring-projects/spring-boot/issues/49209
2. https://github.com/paketo-buildpacks/builder-noble-java-tiny/issues/191