### PR TITLE
Report errors from all configured trust sources

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
@@ -27,8 +27,8 @@ import eu.europa.ec.eudi.trustvalidator.adapter.input.web.SwaggerUi
 import eu.europa.ec.eudi.trustvalidator.adapter.input.web.TrustApi
 import eu.europa.ec.eudi.trustvalidator.adapter.input.web.TrustValidatorUi
 import eu.europa.ec.eudi.trustvalidator.adapter.out.consultation.empty
-import eu.europa.ec.eudi.trustvalidator.adapter.out.consultation.or
 import eu.europa.ec.eudi.trustvalidator.adapter.out.scheduling.dss.CleanupDSSCache
+import eu.europa.ec.eudi.trustvalidator.adapter.out.trust.IsChainTrusted
 import eu.europa.ec.eudi.trustvalidator.config.TrustValidatorConfigurationProperties
 import eu.europa.ec.eudi.trustvalidator.config.isChainTrustedForContextUsingKeyStore
 import eu.europa.ec.eudi.trustvalidator.config.isChainTrustedForContextUsingLoTE
@@ -116,11 +116,15 @@ internal class TrustValidatorServiceContext :
             val isChainTrustedUsingLoTL =
                 bean<IsChainTrustedForContextF<List<X509Certificate>, VerificationContext, TrustAnchor>>("is-chain-trusted-using-lotl")
             val isChainTrustedUsingLoTE =
-                bean<IsChainTrustedForContextF<List<X509Certificate>, VerificationContext, TrustAnchor>>("is-chain-trusted-using-lote")
+                bean<IsChainTrustedForContextF<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>>(
+                    "is-chain-trusted-using-lote",
+                )
             val isChainTrustedUsingKeyStore =
-                bean<IsChainTrustedForContextF<List<X509Certificate>, VerificationContext, TrustAnchor>>("is-chain-trusted-using-keyStore")
+                bean<IsChainTrustedForContextF<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>>(
+                    "is-chain-trusted-using-keyStore",
+                )
 
-            isChainTrustedUsingLoTL or isChainTrustedUsingLoTE or isChainTrustedUsingKeyStore
+            IsChainTrusted(isChainTrustedUsingLoTL, isChainTrustedUsingLoTE, isChainTrustedUsingKeyStore)
         }
 
         registerBean<IsChainTrustedUseCase>()

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/TrustValidatorServiceContext.kt
@@ -21,7 +21,6 @@ import eu.europa.ec.eudi.etsi119602.consultation.ContinueOnProblem
 import eu.europa.ec.eudi.etsi119602.consultation.LoadLoTEAndPointers
 import eu.europa.ec.eudi.etsi1196x2.consultation.DisposableContainer
 import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForContextF
-import eu.europa.ec.eudi.etsi1196x2.consultation.SensitiveApi
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.trustvalidator.adapter.input.web.SwaggerUi
 import eu.europa.ec.eudi.trustvalidator.adapter.input.web.TrustApi
@@ -56,7 +55,6 @@ import java.security.cert.X509Certificate
 import java.util.concurrent.Executors
 import kotlin.time.Clock
 
-@OptIn(SensitiveApi::class)
 internal class TrustValidatorServiceContext :
     BeanRegistrarDsl({
         registerBean { Clock.System }
@@ -114,7 +112,9 @@ internal class TrustValidatorServiceContext :
 
         registerBean {
             val isChainTrustedUsingLoTL =
-                bean<IsChainTrustedForContextF<List<X509Certificate>, VerificationContext, TrustAnchor>>("is-chain-trusted-using-lotl")
+                bean<IsChainTrustedForContextF<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>>(
+                    "is-chain-trusted-using-lotl",
+                )
             val isChainTrustedUsingLoTE =
                 bean<IsChainTrustedForContextF<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>>(
                     "is-chain-trusted-using-lote",

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/adapter/out/trust/IsChainTrusted.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/adapter/out/trust/IsChainTrusted.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.trustvalidator.adapter.out.trust
+
+import arrow.core.nonEmptyListOf
+import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
+import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForContextF
+import eu.europa.ec.eudi.trustvalidator.port.out.trust.CertificateChainTrust
+import eu.europa.ec.eudi.trustvalidator.port.out.trust.IsChainTrusted
+
+fun <CHAIN : Any, CONTEXT : Any, TRUST_ANCHOR : Any> IsChainTrusted(
+    first: IsChainTrustedForContextF<CHAIN, CONTEXT, TRUST_ANCHOR>,
+    vararg remaining: IsChainTrustedForContextF<CHAIN, CONTEXT, TRUST_ANCHOR>,
+): IsChainTrusted<CHAIN, CONTEXT, TRUST_ANCHOR> {
+    suspend infix fun CertificateChainTrust<TRUST_ANCHOR>?.or(
+        other: suspend () -> CertificateChainTrust<TRUST_ANCHOR>?,
+    ): CertificateChainTrust<TRUST_ANCHOR>? =
+        when (this) {
+            is CertificateChainTrust.Trusted -> {
+                this
+            }
+
+            is CertificateChainTrust.NotTrusted -> {
+                when (val otherResult = other()) {
+                    is CertificateChainTrust.Trusted -> otherResult
+                    is CertificateChainTrust.NotTrusted -> CertificateChainTrust.NotTrusted(reasons + otherResult.reasons)
+                    null -> this
+                }
+            }
+
+            null -> {
+                other()
+            }
+        }
+
+    fun <TRUST_ANCHOR : Any> CertificateChainTrust(value: CertificationChainValidation<TRUST_ANCHOR>): CertificateChainTrust<TRUST_ANCHOR> =
+        when (value) {
+            is CertificationChainValidation.Trusted -> CertificateChainTrust.Trusted(value.trustAnchor)
+            is CertificationChainValidation.NotTrusted -> CertificateChainTrust.NotTrusted(nonEmptyListOf(value.cause))
+        }
+
+    val delegates = nonEmptyListOf(first, *remaining)
+    return IsChainTrusted { chain, context ->
+        delegates.fold(null) { accumulator, current ->
+            accumulator or { current(chain, context)?.let { CertificateChainTrust(it) } }
+        }
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/KeyStoreSources.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/KeyStoreSources.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.trustvalidator.config
 
+import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.etsi1196x2.consultation.*
 import eu.europa.ec.eudi.trustvalidator.adapter.out.consultation.or
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +29,7 @@ import java.security.cert.X509Certificate
 private val log = LoggerFactory.getLogger("isChainTrustedForContextUsingKeyStore")
 
 suspend fun TrustSourcesConfigurationProperties.isChainTrustedForContextUsingKeyStore():
-    IsChainTrustedForContext<List<X509Certificate>, VerificationContext, TrustAnchor>? =
+    IsChainTrustedForContext<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>? =
     keyStore?.let {
         val supportedVerificationContexts = configuredVerificationContexts()
         log.info(supportedVerificationContexts)

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/LoTESources.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/LoTESources.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.trustvalidator.config
 
+import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.etsi119602.consultation.*
 import eu.europa.ec.eudi.etsi119602.consultation.eu.ServiceDigitalIdentityCertificateType
 import eu.europa.ec.eudi.etsi119602.consultation.eu.pidSigningCertificateProfile
@@ -23,9 +24,6 @@ import eu.europa.ec.eudi.etsi119602.consultation.eu.wrpAccessCertificateProfile
 import eu.europa.ec.eudi.etsi119602.datamodel.Uri
 import eu.europa.ec.eudi.etsi1196x2.consultation.*
 import io.ktor.client.*
-import io.ktor.client.plugins.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.security.cert.TrustAnchor
@@ -48,7 +46,7 @@ fun TrustSourcesConfigurationProperties.isChainTrustedForContextUsingLoTE(
     clock: Clock,
     continueOnProblem: ContinueOnProblem = ContinueOnProblem.Never,
     constraints: LoadLoTEAndPointers.Constraints,
-): ComposeChainTrust<List<X509Certificate>, VerificationContext, TrustAnchor>? =
+): ComposeChainTrust<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>? =
     loteSources()?.let { (locations, services) ->
         log.info(locations)
         val provisionTrustAnchorsFromLOTE =

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/LoTLSources.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/config/LoTLSources.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.trustvalidator.config
 
+import arrow.core.NonEmptyList
 import eu.europa.ec.eudi.etsi1196x2.consultation.*
 import eu.europa.ec.eudi.etsi1196x2.consultation.dss.ConcurrentCacheDataLoader
 import eu.europa.ec.eudi.etsi1196x2.consultation.dss.DssOptions
@@ -42,7 +43,7 @@ fun TrustSourcesConfigurationProperties.isChainTrustedForContextUsingLoTL(
     cacheDirectory: Path,
     executorService: ExecutorService,
     clock: Clock,
-): IsChainTrustedForContext<List<X509Certificate>, VerificationContext, TrustAnchor>? =
+): IsChainTrustedForContext<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>? =
     lotlSources()
         .takeIf { it.isNotEmpty() }
         ?.let { lotlSources ->
@@ -72,7 +73,7 @@ fun TrustSourcesConfigurationProperties.isChainTrustedForContextUsingLoTL(
 private fun TrustSourcesConfigurationProperties.lotlSources(): Map<VerificationContext, LOTLSource> =
     buildMap {
         // Wallet Providers
-        if (null != walletProviders && null != walletProviders.lotl) {
+        if (walletProviders?.lotl != null) {
             val walletProvidersIssuance = walletProviders.lotl.issuanceLoTLSource()
             val walletProvidersRevocation = walletProviders.lotl.revocationLoTLSource()
 
@@ -81,19 +82,19 @@ private fun TrustSourcesConfigurationProperties.lotlSources(): Map<VerificationC
         }
 
         // PID Providers
-        if (null != pidProviders && null != pidProviders.lotl) {
+        if (pidProviders?.lotl != null) {
             put(VerificationContext.PID, pidProviders.lotl.issuanceLoTLSource())
             put(VerificationContext.PIDStatus, pidProviders.lotl.revocationLoTLSource())
         }
 
         // QEAA Providers
-        if (null != qeaaProviders && null != qeaaProviders.lotl) {
+        if (qeaaProviders?.lotl != null) {
             put(VerificationContext.QEAA, qeaaProviders.lotl.issuanceLoTLSource())
             put(VerificationContext.QEAAStatus, qeaaProviders.lotl.revocationLoTLSource())
         }
 
         // PubEAA Providers
-        if (null != pubEaaProviders && null != pubEaaProviders.lotl) {
+        if (pubEaaProviders?.lotl != null) {
             put(VerificationContext.PubEAA, pubEaaProviders.lotl.issuanceLoTLSource())
             put(VerificationContext.PubEAAStatus, pubEaaProviders.lotl.revocationLoTLSource())
         }
@@ -109,12 +110,12 @@ private fun TrustSourcesConfigurationProperties.lotlSources(): Map<VerificationC
         }
 
         // Wallet Relying Party Access Certificate Providers
-        if (null != wrpacProviders && null != wrpacProviders.lotl) {
+        if (wrpacProviders?.lotl != null) {
             put(VerificationContext.WalletRelyingPartyAccessCertificate, wrpacProviders.lotl.issuanceLoTLSource())
         }
 
         // Wallet Relying Party Registration Certificate Providers
-        if (null != wrprcProviders && null != wrprcProviders.lotl) {
+        if (wrprcProviders?.lotl != null) {
             put(VerificationContext.WalletRelyingPartyRegistrationCertificate, wrprcProviders.lotl.issuanceLoTLSource())
             put(VerificationContext.WalletRelyingPartyRegistrationCertificateStatus, wrprcProviders.lotl.revocationLoTLSource())
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/port/input/trust/IsChainTrustedUseCase.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/port/input/trust/IsChainTrustedUseCase.kt
@@ -17,15 +17,16 @@ package eu.europa.ec.eudi.trustvalidator.port.input.trust
 
 import arrow.core.Either
 import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
 import arrow.core.raise.catch
 import arrow.core.raise.either
 import arrow.core.raise.ensureNotNull
-import eu.europa.ec.eudi.etsi1196x2.consultation.CertificationChainValidation
-import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForContextF
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext.*
 import eu.europa.ec.eudi.trustvalidator.adapter.out.serialization.X509CertificateChainSerializer
 import eu.europa.ec.eudi.trustvalidator.adapter.out.serialization.X509CertificateSerializer
+import eu.europa.ec.eudi.trustvalidator.port.out.trust.CertificateChainTrust
+import eu.europa.ec.eudi.trustvalidator.port.out.trust.IsChainTrusted
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import java.security.cert.TrustAnchor
@@ -80,7 +81,16 @@ data class TrustResponseTO(
     companion object {
         fun trusted(trustAnchor: X509Certificate) = TrustResponseTO(true, trustAnchor, null)
 
-        fun notTrusted(cause: Throwable) = TrustResponseTO(false, null, cause.message)
+        fun notTrusted(reasons: NonEmptyList<Throwable>) =
+            TrustResponseTO(
+                false,
+                null,
+                reasons
+                    .mapNotNull { it.message }
+                    .filter { it.isNotBlank() }
+                    .distinct()
+                    .joinToString(separator = "; "),
+            )
     }
 }
 
@@ -99,21 +109,21 @@ sealed interface ErrorResponseTO {
 }
 
 class IsChainTrustedUseCase(
-    private val isChainTrusted: IsChainTrustedForContextF<List<X509Certificate>, VerificationContext, TrustAnchor>,
+    private val isChainTrusted: IsChainTrusted<NonEmptyList<X509Certificate>, VerificationContext, TrustAnchor>,
 ) {
     suspend operator fun invoke(query: TrustQueryTO): Either<ErrorResponseTO, TrustResponseTO> =
         either {
             val verificationContext = query.verificationContext().bind()
             val result =
                 catch({ isChainTrusted(query.chain, verificationContext) }) { error ->
-                    CertificationChainValidation.NotTrusted(error)
+                    CertificateChainTrust.NotTrusted(nonEmptyListOf(error))
                 }
             ensureNotNull(result) {
                 ErrorResponseTO.ServerErrorResponseTO("No configuration found for VerificationContext $verificationContext")
             }
 
             when (result) {
-                is CertificationChainValidation.Trusted -> {
+                is CertificateChainTrust.Trusted -> {
                     val trustAnchorCertificate =
                         ensureNotNull(result.trustAnchor.trustedCert) {
                             ErrorResponseTO.ServerErrorResponseTO("TrustAnchor was not specified as a X509 Certificate")
@@ -121,8 +131,8 @@ class IsChainTrustedUseCase(
                     TrustResponseTO.trusted(trustAnchorCertificate)
                 }
 
-                is CertificationChainValidation.NotTrusted -> {
-                    TrustResponseTO.notTrusted(result.cause)
+                is CertificateChainTrust.NotTrusted -> {
+                    TrustResponseTO.notTrusted(result.reasons)
                 }
             }
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/port/out/trust/IsChainTrusted.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/trustvalidator/port/out/trust/IsChainTrusted.kt
@@ -13,10 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.trustvalidator.adapter.out.consultation
+package eu.europa.ec.eudi.trustvalidator.port.out.trust
 
-import eu.europa.ec.eudi.etsi1196x2.consultation.IsChainTrustedForContextF
+import arrow.core.NonEmptyList
 
-fun <CHAIN : Any, CONTEXT : Any, TRUST_ANCHOR : Any> IsChainTrustedForContextF.Companion.empty():
-    IsChainTrustedForContextF<CHAIN, CONTEXT, TRUST_ANCHOR> =
-    IsChainTrustedForContextF { _, _ -> null }
+fun interface IsChainTrusted<in CHAIN : Any, in CONTEXT : Any, out TRUST_ANCHOR : Any> {
+    suspend operator fun invoke(
+        chain: CHAIN,
+        context: CONTEXT,
+    ): CertificateChainTrust<TRUST_ANCHOR>?
+}
+
+sealed interface CertificateChainTrust<out TRUST_ANCHOR : Any> {
+    data class Trusted<out TRUST_ANCHOR : Any>(
+        val trustAnchor: TRUST_ANCHOR,
+    ) : CertificateChainTrust<TRUST_ANCHOR>
+
+    class NotTrusted(
+        val reasons: NonEmptyList<Throwable>,
+    ) : CertificateChainTrust<Nothing>
+}


### PR DESCRIPTION
Currently when a Certificate Chain is not trusted for a given `VerificationContext` by any of the configured Trust Sources, Trust Validator returns the error reported only by the Trust Source that was evaluated last.

For LoTE Trust Sources though, a Certificate Chain might not be trusted because the end-entity Certificate violates constraints by the applicable Certificate Profile. 
Given how we compose `IsChainTrustedForContextF` instances though, this information is always lost.

It would be helpful to report errors from all Trust Sources when a Certificate Chain is ultimately not trusted.

This PR introduces `IsChainTrusted`, an analogous to `IsChainTrustedForContextF` but with the following return type:

```kotlin
sealed interface CertificateChainTrust<out TRUST_ANCHOR : Any> {
    data class Trusted<out TRUST_ANCHOR : Any>(
        val trustAnchor: TRUST_ANCHOR,
    ) : CertificateChainTrust<TRUST_ANCHOR>

    class NotTrusted(
        val reasons: NonEmptyList<Throwable>,
    ) : CertificateChainTrust<Nothing>
}
```

When composing multiple `IsChainTrustedForContextF` into a single `IsChainTrusted`, we now can report all the Trust Source errors, and not just the error of the one that was evaluated last.